### PR TITLE
Potential fix for code scanning alert no. 2: Prototype-polluting assignment

### DIFF
--- a/src/components/ProjectEditor.vue
+++ b/src/components/ProjectEditor.vue
@@ -91,6 +91,22 @@ const graphFlow = reactive<GraphFlowItem[]>([]);
 const X_INCREMENT = 150;
 const Y_INCREMENT = 70;
 
+// Keys that must never be used as object property names to avoid prototype pollution
+const DANGEROUS_KEYS = new Set(["__proto__", "constructor", "prototype"]);
+
+/**
+ * Sanitize an identifier so it is safe to use as an object key.
+ * Returns a safe identifier, or null if the input is not usable.
+ */
+function sanitizeId(id: string | undefined | null): string | null {
+    if (!id) return null;
+    if (DANGEROUS_KEYS.has(id)) {
+        // Prefix dangerous keys to ensure they cannot collide with Object.prototype
+        return `id_${id}`;
+    }
+    return id;
+}
+
 /**
  * Available node
  * @notExported
@@ -501,13 +517,17 @@ const saveProjectGraph = (saveAs: boolean): void => {
 
     const graph: ProjectGraph = {};
     for(const node of sortedGraph) {
-        graph[node.id] = {
+        const safeId = sanitizeId(node.id);
+        if (!safeId) {
+            continue;
+        }
+        graph[safeId] = {
             label: node.label,
             type: node.type,
             x: Math.round(node.position.x),
             y: Math.round(node.position.y)
         };
-        if(node.in !== "" && node.in !== "__proto__") graph[node.id].in = node.in;
+        if(node.in !== "" && node.in !== "__proto__") graph[safeId].in = node.in;
     }
 
     askNode("SYSTEM", "modified-project", {
@@ -584,8 +604,8 @@ const handleDrop = (event: DragEvent): void => {
 
     const nodeModel = JSON.parse(event.dataTransfer?.getData("node") ?? "{}") as AvailableNode;
 
-    let id = nodeModel.idPrefix;
-    if(id === undefined) return;
+    let id = sanitizeId(nodeModel.idPrefix);
+    if(id === null) return;
 
     let seq = 0;
     let found = true;


### PR DESCRIPTION
Potential fix for [https://github.com/crystalfp/STMng/security/code-scanning/2](https://github.com/crystalfp/STMng/security/code-scanning/2)

In general, to fix prototype-polluting assignments, avoid using untrusted strings as property names on plain objects. Either: (1) use a safer key/value structure like `Map`, or (2) sanitize/validate keys so they cannot be `"__proto__"`, `"constructor"`, or `"prototype"` (or otherwise clash with built-in properties).

Here, the minimal, behavior-preserving fix is to sanitize the `id` used both when constructing nodes and when later building the `graph` object. The safest approach without refactoring types is:
- Introduce a small helper function (inside this file) that takes a string ID and either:
  - rejects dangerous values by throwing or returning a safe fallback, or
  - prefixes them so they can’t match built-in property names.
- Use this helper:
  - When creating new nodes in `handleDrop`, normalize `id` before storing it in `graphFlow`.
  - When creating the `graph` object, normalize `node.id` before using it as a key (`graph[safeId]` instead of `graph[node.id]`).

Since we must not change behavior more than necessary, a practical choice is to *reject* dangerous IDs when building `graph` (skip nodes whose IDs normalize to `null`), and to *prevent* creating such IDs in the first place during drag-and-drop by prefixing them with a constant if they are dangerous. This guarantees `graph` never receives dangerous keys while maintaining uniqueness semantics.

Concretely:
- Add a helper function near the other constants (e.g., after `const Y_INCREMENT = 70;`) such as:

  ```ts
  const DANGEROUS_KEYS = new Set(["__proto__", "constructor", "prototype"]);

  function sanitizeId(id: string | undefined | null): string | null {
      if (!id) return null;
      if (DANGEROUS_KEYS.has(id)) {
          // Prevent prototype pollution by never using these as keys.
          return `id_${id}`;
      }
      return id;
  }
  ```

  This keeps functionality very close to existing behavior: `"__proto__"` becomes `"id___proto__"`, which still includes the original prefix but is safe as an object key.

- In `handleDrop`, after computing `let id = nodeModel.idPrefix;`, run it through `sanitizeId`, and bail out if it returns `null`. Also ensure the uniqueness loop uses the sanitized base and constructs IDs from it (dangerous prefixes will thus always be prefixed and safe).
- In the project-saving loop where `graph[node.id]` is assigned, use `const safeId = sanitizeId(node.id);` and only assign if `safeId` is non-null: `graph[safeId] = { ... }`.

No new imports are necessary; the helper uses only built-in language features.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
